### PR TITLE
add `JvmOverloads` & made `init` method open

### DIFF
--- a/src/main/kotlin/dev/debuggings/clickgui/ClickGui.kt
+++ b/src/main/kotlin/dev/debuggings/clickgui/ClickGui.kt
@@ -14,7 +14,7 @@ import gg.essential.elementa.dsl.*
 import net.minecraftforge.common.MinecraftForge
 import java.awt.Color
 
-open class ClickGui(configPath: String, color: Color? = null) : WindowScreen(ElementaVersion.V1) {
+open class ClickGui @JvmOverloads constructor(configPath: String, color: Color? = null) : WindowScreen(ElementaVersion.V1) {
     private lateinit var colorHandler: ColorHandler
     var color = color
         set(value) {
@@ -39,7 +39,7 @@ open class ClickGui(configPath: String, color: Color? = null) : WindowScreen(Ele
         textScale = 0.5.pixel
     } childOf descBlock
 
-    fun init() {
+    open fun init() {
         config.load()
         sections.forEach {
             it.init()

--- a/src/main/kotlin/dev/debuggings/clickgui/elements/ButtonElement.kt
+++ b/src/main/kotlin/dev/debuggings/clickgui/elements/ButtonElement.kt
@@ -10,7 +10,7 @@ import gg.essential.elementa.dsl.pixel
 import gg.essential.elementa.dsl.toConstraint
 import gg.essential.universal.UKeyboard
 
-class ButtonElement(
+class ButtonElement @JvmOverloads constructor(
     name: String,
     allowBinding: Boolean = false,
     override var description: String? = null,

--- a/src/main/kotlin/dev/debuggings/clickgui/elements/ColorPickerElement.kt
+++ b/src/main/kotlin/dev/debuggings/clickgui/elements/ColorPickerElement.kt
@@ -13,7 +13,7 @@ import gg.essential.elementa.dsl.pixel
 import gg.essential.elementa.dsl.toConstraint
 import java.awt.Color
 
-class ColorPickerElement(
+class ColorPickerElement @JvmOverloads constructor(
     name: String,
     private val defaultValue: Color,
     override var description: String? = null,

--- a/src/main/kotlin/dev/debuggings/clickgui/elements/DecimalSliderElement.kt
+++ b/src/main/kotlin/dev/debuggings/clickgui/elements/DecimalSliderElement.kt
@@ -12,7 +12,7 @@ import gg.essential.elementa.dsl.pixel
 import gg.essential.elementa.dsl.toConstraint
 import kotlin.math.floor
 
-class DecimalSliderElement(
+class DecimalSliderElement @JvmOverloads constructor(
     name: String,
     private val minValue: Float,
     private val maxValue: Float,

--- a/src/main/kotlin/dev/debuggings/clickgui/elements/DividerElement.kt
+++ b/src/main/kotlin/dev/debuggings/clickgui/elements/DividerElement.kt
@@ -7,7 +7,7 @@ import gg.essential.elementa.dsl.constrain
 import gg.essential.elementa.dsl.pixel
 import gg.essential.elementa.dsl.toConstraint
 
-class DividerElement(name: String? = null) : Element<String>("", "") {
+class DividerElement @JvmOverloads constructor(name: String? = null) : Element<String>("", "") {
 
     fun setHeight(height: Number) = constrain {
         this.height = height.pixel()

--- a/src/main/kotlin/dev/debuggings/clickgui/elements/SecureToggleElement.kt
+++ b/src/main/kotlin/dev/debuggings/clickgui/elements/SecureToggleElement.kt
@@ -8,7 +8,7 @@ import gg.essential.elementa.dsl.constrain
 import gg.essential.elementa.dsl.pixel
 import gg.essential.elementa.dsl.toConstraint
 
-class SecureToggleElement(
+class SecureToggleElement @JvmOverloads constructor(
     name: String,
     private val defaultValue: Boolean = false,
     override var description: String? = null,

--- a/src/main/kotlin/dev/debuggings/clickgui/elements/SelectElement.kt
+++ b/src/main/kotlin/dev/debuggings/clickgui/elements/SelectElement.kt
@@ -8,7 +8,7 @@ import gg.essential.elementa.dsl.constrain
 import gg.essential.elementa.dsl.pixel
 import gg.essential.elementa.dsl.toConstraint
 
-class SelectElement(
+class SelectElement @JvmOverloads constructor(
     name: String,
     private val defaultValue: String,
     private val options: ArrayList<String>,

--- a/src/main/kotlin/dev/debuggings/clickgui/elements/SliderElement.kt
+++ b/src/main/kotlin/dev/debuggings/clickgui/elements/SliderElement.kt
@@ -11,7 +11,7 @@ import gg.essential.elementa.dsl.constrain
 import gg.essential.elementa.dsl.pixel
 import gg.essential.elementa.dsl.toConstraint
 
-class SliderElement(
+class SliderElement @JvmOverloads constructor(
     name: String,
     private val minValue: Int,
     private val maxValue: Int,

--- a/src/main/kotlin/dev/debuggings/clickgui/elements/SubSection.kt
+++ b/src/main/kotlin/dev/debuggings/clickgui/elements/SubSection.kt
@@ -13,7 +13,7 @@ import gg.essential.elementa.dsl.pixel
 import gg.essential.elementa.dsl.toConstraint
 import gg.essential.universal.UKeyboard
 
-class SubSection(
+class SubSection @JvmOverloads constructor(
     val name: String,
     private val defaultValue: Boolean = false,
     private val saveState: Boolean = true,

--- a/src/main/kotlin/dev/debuggings/clickgui/elements/TextInputElement.kt
+++ b/src/main/kotlin/dev/debuggings/clickgui/elements/TextInputElement.kt
@@ -10,7 +10,7 @@ import gg.essential.elementa.dsl.constrain
 import gg.essential.elementa.dsl.pixel
 import gg.essential.elementa.dsl.toConstraint
 
-class TextInputElement(
+class TextInputElement @JvmOverloads constructor(
     name: String,
     private val defaultValue: String,
     override var description: String? = null,

--- a/src/main/kotlin/dev/debuggings/clickgui/elements/ToggleElement.kt
+++ b/src/main/kotlin/dev/debuggings/clickgui/elements/ToggleElement.kt
@@ -10,7 +10,7 @@ import gg.essential.elementa.dsl.pixel
 import gg.essential.elementa.dsl.toConstraint
 import gg.essential.universal.UKeyboard
 
-class ToggleElement(
+class ToggleElement @JvmOverloads constructor(
     val name: String,
     val defaultValue: Boolean = false,
     private val saveState: Boolean = true,


### PR DESCRIPTION
`JvmOverload` is kind of useless now but i'm too lazy to remove and why not
`init` being open allows me to easily make a `Chattriggers` wrapper for the gui without (hopefully) changing the main functionality of this lib